### PR TITLE
fix gifsicle executable on Windows

### DIFF
--- a/empupload/media.py
+++ b/empupload/media.py
@@ -103,7 +103,7 @@ retrives gifsicle path based on os
 def gifsicleHelper():
     if sys.platform=="linux":
         return shutil.which("gifsicle") or os.path.join(settings.gifsicle,"gifsicle")
-    return shutil.which("gifsicle") or os.path.join(settings.gifsicle,"gifsicle")
+    return shutil.which("gifsicle.exe") or os.path.join(settings.gifsicle,"gifsicle.exe")
 
     
 


### PR DESCRIPTION
Before this commit the process of GIF creation via gifsicle wouldn't work on Windows because the `.exe` was missing at the the end of `gifsicle`.

It resulted in the following error:
```
Starting GIF Process
Splitting section of video from 2493.75 secs to 2498.75 secs
Creating GIF from section
Compressing GIF
[WinError 193] %1 is not a valid Win32 application
```

This commit fixes the error and allows the GIF to be successfully created on Windows.